### PR TITLE
Upgrade to Play 2.0.4

### DIFF
--- a/module/app/com/github/cleverage/elasticsearch/IndexQuery.java
+++ b/module/app/com/github/cleverage/elasticsearch/IndexQuery.java
@@ -1,7 +1,7 @@
 package com.github.cleverage.elasticsearch;
 
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Validate;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;

--- a/module/project/plugins.sbt
+++ b/module/project/plugins.sbt
@@ -5,4 +5,4 @@ logLevel := Level.Warn
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("play" % "sbt-plugin" % "2.0.2")
+addSbtPlugin("play" % "sbt-plugin" % "2.0.4")

--- a/samples/elasticsearch-java/project/plugins.sbt
+++ b/samples/elasticsearch-java/project/plugins.sbt
@@ -5,4 +5,4 @@ logLevel := Level.Warn
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("play" % "sbt-plugin" % "2.0.2")
+addSbtPlugin("play" % "sbt-plugin" % "2.0.4")


### PR DESCRIPTION
As part of the 2.0.4 update, Play changed from commons-lang to commons-lang3.
