### PR TITLE
Added byIdAsync to Finder in Index

### DIFF
--- a/module/app/com/github/cleverage/elasticsearch/Index.java
+++ b/module/app/com/github/cleverage/elasticsearch/Index.java
@@ -192,6 +192,15 @@ public abstract class Index implements Indexable {
         }
 
         /**
+         * Asynchronously retrieves an entity by ID.
+         * @param id
+         * @return
+         */
+        public F.Promise<T> byIdAsync(String id){
+            return IndexService.getAsync(queryPath, type, id);
+        };
+
+        /**
          * Retrieves all entities of the given type.
          */
         public IndexResults<T> all() {


### PR DESCRIPTION
This is to make getAsync available through the Index entities
