### PR TITLE
Disable dynamic querys by default, to avoid remote code execution. 

### DIFF
--- a/module/app/com/github/cleverage/elasticsearch/IndexConfig.java
+++ b/module/app/com/github/cleverage/elasticsearch/IndexConfig.java
@@ -41,7 +41,7 @@ public class IndexConfig {
     public Boolean sniffing = true;
 
     /**
-     * elasticsearch.local.config = configuration file load on local mode.
+     * elasticsearch.config.resource = configuration file load on local mode.
      * eg : conf/elasticsearch.yml
      */
     public String localConfig = null;

--- a/module/conf/elasticsearch.yml
+++ b/module/conf/elasticsearch.yml
@@ -3,3 +3,5 @@
 cluster.name: play2-elasticsearch
 
 path.data: data
+
+script.disable_dynamic: true


### PR DESCRIPTION
Elasticsearch defaults to support dynamic querys, which introduces a risk for remote code execution. This is supposedly disabled by default in newer versions of ES, but for now, I suggest setting it to false in the default configuration is better than nothing.

For more information, please see http://bouk.co/blog/elasticsearch-rce/

Br,
Jan
