### PR TITLE
supressing default index creation

### DIFF
--- a/module/conf/reference.conf
+++ b/module/conf/reference.conf
@@ -22,7 +22,6 @@ elasticsearch.local=true
 
 ###### Index Name
 ## Name(s) of the index ( if multiple : separate by ',' )
-elasticsearch.index.name="play2-elasticsearch"
 # elasticsearch.index.name="index1,index2,..."
 
 ###### Index Settings


### PR DESCRIPTION
commenting index name to stop creating play2-elasticsearch named index whenever no index name is specified in config